### PR TITLE
Add dockerized script to run protoc and protobuf_uml_diagram.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3-buster
+RUN apt-get update && apt-get install -y curl graphviz \
+  && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip -o protoc-3.7.1.zip \
+  && unzip protoc-3.7.1.zip -d protoc-3.7.1 \
+  && mv protoc-3.7.1/bin/* /usr/local/bin/ \
+  && mv protoc-3.7.1/include/* /usr/local/include/ \
+  && pip install "click==7.0.*" "graphviz==0.10.*" "protobuf==3.7.*"
+ADD docker/gen_uml.sh /
+ADD protobuf_uml_diagram.py /
+CMD [ "/bin/bash", "./run.sh" ]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ $ pip install .
 $ protobuf-uml-diagram
 ```
 
+## Alternative to installation
+
+Generate UML diagrams from all (uncompiled) `.proto` files in a directory:
+
+```
+./dockerbuild.sh
+./dockerrun.sh <path_containing_proto_files> <output_path>
+```
+
 ## License
 
 Apache License

--- a/docker/gen_uml.sh
+++ b/docker/gen_uml.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+PROTO_PATH="/in"
+echo "MODULE:${MODULE}"
+PYTHONPATH="/out/python"
+
+mkdir -p ${PYTHONPATH}
+
+protoc --proto_path=${PROTO_PATH} -I=/usr/include --python_out=${PYTHONPATH} $(find ${PROTO_PATH} -name '*.proto')
+
+export PYTHONPATH
+for p in $(find ${PROTO_PATH} -name '*.proto'); do
+    p="${p/\/in\//}"
+    p="${p/\//.}"
+    p="${p/.proto/_pb2}"
+    python protobuf_uml_diagram.py --proto ${p} --output=/out
+done

--- a/dockerbuild.sh
+++ b/dockerbuild.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ docker build -t pb_uml .

--- a/dockerrun.sh
+++ b/dockerrun.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# WSL restrictions force insanity with respect to paths when using Windows Docker Desktop
+#
+#./dockerrun.sh /c/Users/cfesler/src/kairos/proto /c/Users/cfesler/src/out
+
+IN_DIR=$1
+OUT_DIR=$2
+docker run -ti --mount type=bind,source=${OUT_DIR},target=/out --mount type=bind,source=${IN_DIR},target=/in pb_uml:latest /bin/bash /gen_uml.sh


### PR DESCRIPTION
@kinow here's another offering -- this commit gives one the ability to generate UML for every `.proto` file with two commands:

```
./dockerbuild.sh
./dockerrun.sh <input_dir> <output_dir>
```

I used docker because I didn't want to deal with setting up python. : )

Totally makes sense if you don't want this in your codebase -- but also might make it easier for others to use? 

Anyway, thanks again for the sweet utility!