### PR TITLE
Add --format option to CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,5 +74,7 @@ jobs:
           bash dockerbuild.sh
           mkdir -p $(pwd)/test_data/out
           bash dockerrun.sh $(pwd -P)/test_data/ $(pwd)/test_data/out
+          [ -f "./test_data/out/issue_10_pb2.svg" ] || exit 1
+          [ -f "./test_data/out/issue_10_pb2.png" ] || exit 1
 
 # TODO: publish to PYPI in GH actions? see skosmos-client & other natlib workflows

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Test data
+test_data/out/
+

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@
 - Update types-protobuf requirement from ==4.24.* to >=4.24,<5.30 #88 #89 #100 #103
 - Use codecov GH Action instead of Shell, use GH Secret #91
 - Set GH Action checkout depth to 2 to fix Codecov error #91
-- Dropped Python 3.7 so we can use pytest-env #81
+- Dropped Python 3.7, so we can use pytest-env #81
+- Add --format option to CLI (thanks @dcunited001) #109
 
 ## 0.13 (22/11/2023)
 

--- a/docker/gen_uml.sh
+++ b/docker/gen_uml.sh
@@ -12,5 +12,6 @@ for p in $(find ${PROTO_PATH} -name '*.proto'); do
     p="${p/\/in\//}"
     p="${p/\//.}"
     p="${p/.proto/_pb2}"
-    python protobuf_uml_diagram.py --proto "${p}" --output=/out
+    python protobuf_uml_diagram.py --proto "${p}" --output=/out --format png
+    python protobuf_uml_diagram.py --proto "${p}" --output=/out --format svg
 done

--- a/dockerbuild.sh
+++ b/dockerbuild.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
- docker build -t pb_uml .
+
+docker build --load -t pb_uml .

--- a/dockerrun.sh
+++ b/dockerrun.sh
@@ -5,4 +5,10 @@
 
 IN_DIR=$1
 OUT_DIR=$2
-docker run --mount type=bind,source="${OUT_DIR}",target=/out --mount type=bind,source="${IN_DIR}",target=/in pb_uml:latest /bin/bash /gen_uml.sh
+
+docker run \
+  --mount type=bind,source="${OUT_DIR}",target=/out \
+  --mount type=bind,source="${IN_DIR}",target=/in \
+  pb_uml:latest \
+  /bin/bash \
+  /gen_uml.sh

--- a/protobuf_uml_diagram.py
+++ b/protobuf_uml_diagram.py
@@ -256,11 +256,14 @@ class Diagram:
               help='Output directory.')
 @click.option('--full_names', type=bool, required=False, default=True,
               help='Use full names (Class.type) or not (type) in diagram.')
-def main(proto: str, output: Path, full_names: bool) -> None:
+@click.option('--format', '_format', type=click.Choice(["png", "svg"]), required=False, default="png",
+              help='Diagram output format (e.g. png, svg).')
+def main(proto: str, output: Path, full_names: bool, _format: str) -> None:
     Diagram() \
         .from_file(proto) \
         .to_file(output) \
         .with_full_names(full_names) \
+        .with_format(_format) \
         .build()
 
 


### PR DESCRIPTION
Add --format option to CLI.

I ran the tests in GH actions on my fork. 

I also generated `svg` [here](https://github.com/dcunited001/zettelkasten/blob/master/dcguix/packages/protobuf/protobuf-uml-diagram.org#testing-svg-output) in my zettelkasten.  

I could've tested in docker, but it's just simpler for me to add the package to a guix profile for some use cases.