### PR TITLE
Remove macos from build, and add py311 to linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ]
-        python: [3.8, 3.9, '3.10']
-        include:
-          - os: 'darwin'
-            python: '3.8'
-            experimental: true
+        python: [3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Set GH Action checkout depth to 2 to fix Codecov error #91
 - Dropped Python 3.7, so we can use pytest-env #81
 - Add --format option to CLI (thanks @dcunited001) #109
+- Dropped darwin OS from GH Actions, add py3.11 to the matrix #110
 
 ## 0.13 (22/11/2023)
 


### PR DESCRIPTION
~The darwin tests keep hanging. Let's see if this fixes that.~

Well, good bye macos tests. Would have to install graphviz in macos-latest, and maintenance-cost is not worth.